### PR TITLE
[FIX]: working version on minikube cluster

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -17,8 +17,8 @@ spec:
     spec:
       containers:
         - name: simple-app
-          imagePullPolicy: Always
-          image: simple-app-simple-app:latest
+          imagePullPolicy: Never
+          image: simple-app:test
           ports:
             - containerPort: 8000
           resources:

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -15,10 +15,3 @@ spec:
                 name: simple-app-service
                 port:
                   number: 80
-          - path: /health
-            pathType: Prefix
-            backend:
-              service:
-                name: simple-app-service
-                port:
-                  number: 80


### PR DESCRIPTION
# Description 
Fix the minikube issue 

# Steps for a working version 
- Docker build locally and and load the image into **minikube** cluster via 
```bash 
eval $(minikube docker-env)

# use the same name as the image name in the `k8s/deployment.yaml` file
docker build -t simple-app:test .

minikube image load simple-app:test

```
- create a namespace named **simple-app-ns** (or chose another name, but make sure that the namespace name is the same in all the files, or get reid of them all at once, but i think isolation is better)
```bash 
kubectl craete ns simple-app-ns
```
- apply via kubectl 
```bash 
kubectl apply -f k8s/ 
```
- assuming there aren't errors (use logs/get/describe subcommands to spot them if exists), then let's tunnel ir via minikube or use the kubectl directly with port-forward subcommand 
```bash 
# 1st method 
minikube tunnel 
## get the cluster ip and use it as access point in your client
kubectl get svc -n simple-app-ns

# 2nd method 
## i chose port 8080 since here, but you can chose any port that is not mapped on your local machine
kubectl port-forward -n simple-app-ns svc/simple-app-service 8080:80
```

